### PR TITLE
Generate hashes for installers

### DIFF
--- a/.scripts/run.bat
+++ b/.scripts/run.bat
@@ -3,5 +3,5 @@
 conda.exe install -yq constructor jinja2
 if errorlevel 1 exit 1
 
-build.py --python "%PYVER%"
+build.py --python "%PYVER%" --hash md5 sha1 sha256
 if errorlevel 1 exit 1

--- a/.scripts/run.sh
+++ b/.scripts/run.sh
@@ -3,4 +3,4 @@
 set -x
 
 conda install -yq constructor jinja2
-./build.py --python "${PYVER}"
+./build.py --python "${PYVER}" --hash md5 sha1 sha256

--- a/build.py
+++ b/build.py
@@ -147,26 +147,29 @@ def main(*argv):
             "--cache-dir", cache_dir
         ])
 
-        for fn in os.listdir(out_tmp_dir):
-            fn = os.path.join(out_tmp_dir, fn)
-            if os.path.isfile(fn):
-                print("Computing hashes for \"%s\"." % os.path.basename(fn))
-
-                fn_hashes = {}
-                for hn in hash_names:
-                    h = subprocess.check_output(
-                        ["openssl", hn, fn],
-                        universal_newlines=True
+        if hash_names:
+            for fn in os.listdir(out_tmp_dir):
+                fn = os.path.join(out_tmp_dir, fn)
+                if os.path.isfile(fn):
+                    print(
+                        "Computing hashes for \"%s\"." % os.path.basename(fn)
                     )
-                    h = h.split()[-1]
-                    fn_hashes[hn] = h
 
-                print("Writing out hashes.")
-                for hn in hash_names:
-                    h = fn_hashes[hn]
-                    with open(fn + os.extsep + hn, "w") as fh:
-                        fh.write(h)
-                        fh.write("\n")
+                    fn_hashes = {}
+                    for hn in hash_names:
+                        h = subprocess.check_output(
+                            ["openssl", hn, fn],
+                            universal_newlines=True
+                        )
+                        h = h.split()[-1]
+                        fn_hashes[hn] = h
+
+                    print("Writing out hashes.")
+                    for hn in hash_names:
+                        h = fn_hashes[hn]
+                        with open(fn + os.extsep + hn, "w") as fh:
+                            fh.write(h)
+                            fh.write("\n")
 
         shutil.move(out_tmp_dir, out_dir)
 

--- a/build.py
+++ b/build.py
@@ -3,6 +3,7 @@
 import argparse
 import contextlib
 import datetime
+import hashlib
 import os
 import shutil
 import subprocess
@@ -72,6 +73,14 @@ def main(*argv):
         type=str,
         help="Python version to use in install"
     )
+    parser.add_argument(
+        "--hash",
+        type=str,
+        nargs="*",
+        default=[],
+        dest="hash_names",
+        help="Hashes to run on each installer"
+    )
     args = parser.parse_args(args=argv[1:])
 
     py_ver = []
@@ -85,6 +94,10 @@ def main(*argv):
 
     py_ver_maj = py_ver[0]
     py_ver_min = py_ver[1]
+
+    hash_names = args.hash_names
+    for hn in hash_names:
+        hashlib.new(hn)
 
     base_dir = os.path.dirname(os.path.abspath(__name__))
     src_dir = os.path.join(base_dir, "src")
@@ -133,6 +146,27 @@ def main(*argv):
             "--output-dir", out_tmp_dir,
             "--cache-dir", cache_dir
         ])
+
+        for fn in os.listdir(out_tmp_dir):
+            fn = os.path.join(out_tmp_dir, fn)
+            if os.path.isfile(fn):
+                print("Computing hashes for \"%s\"." % os.path.basename(fn))
+
+                fn_hashes = {}
+                for hn in hash_names:
+                    h = subprocess.check_output(
+                        ["openssl", hn, fn],
+                        universal_newlines=True
+                    )
+                    h = h.split()[-1]
+                    fn_hashes[hn] = h
+
+                print("Writing out hashes.")
+                for hn in hash_names:
+                    h = fn_hashes[hn]
+                    with open(fn + os.extsep + hn, "w") as fh:
+                        fh.write(h)
+                        fh.write("\n")
 
         shutil.move(out_tmp_dir, out_dir)
 


### PR DESCRIPTION
Fixes https://github.com/jakirkham/miniforge/issues/4

Creates `md5`, `sha1`, and `sha256` hashes for the installers. The `md5` hash is provided mainly for compatibility with Miniconda (though really should not be relied upon). Similarly `sha1` is becoming less reliable. However on older OSes `sha1` can be gotten pretty reliably and is much better than `md5`. Finally `sha256` is provided to give a sturdy checksum that is increasingly relied upon by PyPI and conda-forge. These are all written out to files that share the same name as the installer, but with the checksum appended as an extension.