### PR TITLE
Drop `defaults` from `channels`

### DIFF
--- a/src/construct.yaml
+++ b/src/construct.yaml
@@ -9,11 +9,6 @@ install_in_dependency_order: true
 
 channels:
   - http://conda.anaconda.org/conda-forge
-  - https://repo.continuum.io/pkgs/main
-  - https://repo.continuum.io/pkgs/free
-  - https://repo.continuum.io/pkgs/r
-  - https://repo.continuum.io/pkgs/pro
-  - https://repo.continuum.io/pkgs/msys2
 
 specs:
   - python {{ py_ver_maj }}.{{ py_ver_min }}.*


### PR DESCRIPTION
Builds the installer using only `conda-forge` without `defaults`.