### PR TITLE
Fix CRLF/LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto
+
+*.bat text eol=crlf
+*.py text eol=lf
+*.sh text eol=lf
+
+*.md text eol=lf
+*.rst text eol=lf
+*.txt text eol=lf
+
+*.yml text eol=lf


### PR DESCRIPTION
Adds a `.gitattributes` file to fix up line endings. Then removes and readds everything to make sure that `git` picks up on anything that should have different line endings and enforces it. Mainly fixes a batch script included for the CI build.