### PR TITLE
Unbuffer Python stdout/stderr

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,8 @@ branches:
   - master
 
 environment:
+  global:
+    PYTHONUNBUFFERED: 1
 
   matrix:
     - TARGET_ARCH: x86

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     working_directory: ~/test
     machine: true
     environment:
+      - PYTHONUNBUFFERED: 1
       - PYVER: "27"
     steps:
       - checkout
@@ -19,6 +20,7 @@ jobs:
     working_directory: ~/test
     machine: true
     environment:
+      - PYTHONUNBUFFERED: 1
       - PYVER: "35"
     steps:
       - checkout
@@ -33,6 +35,7 @@ jobs:
     working_directory: ~/test
     machine: true
     environment:
+      - PYTHONUNBUFFERED: 1
       - PYVER: "36"
     steps:
       - checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ branches:
   - master
 
 env:
-  - PYVER="27"
-  - PYVER="35"
-  - PYVER="36"
+  matrix:
+    - PYVER="27"
+    - PYVER="35"
+    - PYVER="36"
 
 before_install:
   - curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ branches:
   - master
 
 env:
+  global:
+    - PYTHONUNBUFFERED=1
   matrix:
     - PYVER="27"
     - PYVER="35"


### PR DESCRIPTION
To make sure that everything gets printed in the intended order and is not interspersed with other output, set `PYTHONUNBUFFERED` for all CI builds.