### PR TITLE
Add a distclean script

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,3 +47,4 @@ build: off
 test_script:
   - cmd: .scripts\\run.bat
   - cmd: check "out\\miniforge-py%PYVER%-*.exe"
+  - cmd: distclean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ jobs:
           command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil .scripts/run.sh
       - run:
           command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
+      - run:
+          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil ./distclean.py
 
   build_python_35:
     working_directory: ~/test
@@ -30,6 +32,8 @@ jobs:
           command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil .scripts/run.sh
       - run:
           command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
+      - run:
+          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil ./distclean.py
 
   build_python_36:
     working_directory: ~/test
@@ -45,6 +49,8 @@ jobs:
           command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil .scripts/run.sh
       - run:
           command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
+      - run:
+          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil ./distclean.py
 
   test_release:
     working_directory: ~/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ install:
 script:
   - .scripts/run.sh
   - ./check.py "out/miniforge-py${PYVER}-*.sh"
+  - ./distclean.py

--- a/build.py
+++ b/build.py
@@ -78,8 +78,8 @@ def main(*argv):
     _scripts_dir = os.path.join(base_dir, ".scripts")
 
     out_dir = os.path.join(base_dir, "out")
-    if os.path.exists(out_dir):
-        shutil.rmtree(out_dir)
+    if not os.path.exists(out_dir):
+        os.mkdir(out_dir)
 
     git_time_str = subprocess.check_output(
         [sys.executable, os.path.join(_scripts_dir, "version.py")],
@@ -149,7 +149,9 @@ def main(*argv):
                             fh.write(h)
                             fh.write("\n")
 
-        shutil.move(out_tmp_dir, out_dir)
+        for each_fn in os.listdir(out_tmp_dir):
+            each_fn = os.path.join(out_tmp_dir, each_fn)
+            shutil.move(each_fn, out_dir)
 
         print("Moved installer to: %s" % out_dir)
 

--- a/distclean.py
+++ b/distclean.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import shutil
+import sys
+
+
+def main(*argv):
+    parser = argparse.ArgumentParser(
+        description="Cleanup any installers in `out`."
+    )
+    args = parser.parse_args(args=argv[1:])
+
+    base_dir = os.path.dirname(os.path.abspath(__name__))
+    out_dir = os.path.join(base_dir, "out")
+
+    if os.path.exists(out_dir):
+        shutil.rmtree(out_dir)
+
+
+if __name__ == "__main__":
+    sys.exit(main(*sys.argv))


### PR DESCRIPTION
Provides a `distclean` script to cleanup the installers. Also uses them at the end of CI builds in an effort to test them and also proactively clean to prepare for selective caching.