### PR TITLE
Work in the `conda` user's home directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,11 @@ jobs:
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil .scripts/run.sh
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil .scripts/run.sh
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./distclean.py
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./distclean.py
 
   build_python_35:
     working_directory: ~/test
@@ -29,11 +29,11 @@ jobs:
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil .scripts/run.sh
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil .scripts/run.sh
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./distclean.py
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./distclean.py
 
   build_python_36:
     working_directory: ~/test
@@ -46,11 +46,11 @@ jobs:
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil .scripts/run.sh
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil .scripts/run.sh
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./distclean.py
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./distclean.py
 
   test_release:
     working_directory: ~/test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,11 @@ jobs:
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil .scripts/run.sh
+          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil .scripts/run.sh
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
+          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil ./distclean.py
+          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./distclean.py
 
   build_python_35:
     working_directory: ~/test
@@ -29,11 +29,11 @@ jobs:
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil .scripts/run.sh
+          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil .scripts/run.sh
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
+          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil ./distclean.py
+          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./distclean.py
 
   build_python_36:
     working_directory: ~/test
@@ -46,11 +46,11 @@ jobs:
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil .scripts/run.sh
+          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil .scripts/run.sh
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
+          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
       - run:
-          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/repo -w /repo condaforge/linux-anvil ./distclean.py
+          command: docker run -it -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./distclean.py
 
   test_release:
     working_directory: ~/test


### PR DESCRIPTION
Now that we are not running as `root`, we need to mount the repo into a directory that we will have write permissions in. We pick the `conda` user's home directory as that is the username we take when starting up the container now.