### PR TITLE
Make sure to run `distclean` before CI builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,6 +45,7 @@ install:
 build: off
 
 test_script:
+  - cmd: distclean
   - cmd: .appveyor_scripts\\run.bat
   - cmd: check "out\\miniforge-py%PYVER%-*.exe"
   - cmd: distclean

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -4,6 +4,7 @@ set -ex
 
 conda install -yq constructor jinja2
 
+/home/conda/repo/distclean.py
 /home/conda/repo/build.py --python "${PYVER}" --hash md5 sha1 sha256
 /home/conda/repo/check.py out/miniforge-py${PYVER}-*.sh
 /home/conda/repo/distclean.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
   - conda config --set auto_update_conda false
 
 script:
+  - ./distclean.py
   - .travis_scripts/run.sh
   - ./check.py "out/miniforge-py${PYVER}-*.sh"
   - ./distclean.py


### PR DESCRIPTION
In order to prepare for caching, make sure that we are clearing the results from any previous build before starting a new build. This way we are not allowing the cache to accumulate between builds. Only allowing the cache to include whatever we built from the current build where we didn't cleanup afterwards.