### PR TITLE
Use absolute paths with CircleCI scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,11 @@ jobs:
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
-          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil .scripts/run.sh
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/.scripts/run.sh
       - run:
-          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/check.py "out/miniforge-py${PYVER}-*.sh"
       - run:
-          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./distclean.py
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/distclean.py
 
   build_python_35:
     working_directory: ~/test
@@ -29,11 +29,11 @@ jobs:
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
-          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil .scripts/run.sh
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/.scripts/run.sh
       - run:
-          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/check.py "out/miniforge-py${PYVER}-*.sh"
       - run:
-          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./distclean.py
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/distclean.py
 
   build_python_36:
     working_directory: ~/test
@@ -46,11 +46,11 @@ jobs:
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
-          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil .scripts/run.sh
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/.scripts/run.sh
       - run:
-          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./check.py "out/miniforge-py${PYVER}-*.sh"
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/check.py "out/miniforge-py${PYVER}-*.sh"
       - run:
-          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo -w /home/conda/repo condaforge/linux-anvil ./distclean.py
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/distclean.py
 
   test_release:
     working_directory: ~/test


### PR DESCRIPTION
As the `condaforge/linux-anvil` image no longer respects the `-w` argument (since it drops into the `conda` user's home directory), quit specifying `-w` and switch to using absolute paths to the scripts. While the absolute paths may not be strictly necessary, this should remain robust as `condaforge/linux-anvil` evolves.