### PR TITLE
Try caching the installers on CIs for release

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,4 +48,7 @@ test_script:
   - cmd: distclean
   - cmd: .appveyor_scripts\\run.bat
   - cmd: check "out\\miniforge-py%PYVER%-*.exe"
-  - cmd: distclean
+  - cmd: if defined APPVEYOR_PULL_REQUEST_NUMBER (distclean)
+
+cache:
+  - out

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,17 @@ jobs:
       - PYVER: "27"
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - build_python_27-{{ .Revision }}
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
-          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/.circleci/run.sh
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -e CIRCLE_PULL_REQUEST="${CIRCLE_PULL_REQUEST}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/.circleci/run.sh
+      - save_cache:
+          key: build_python_27-{{ .Revision }}
+          paths:
+            - out
 
   build_python_35:
     working_directory: ~/test
@@ -22,10 +29,17 @@ jobs:
       - PYVER: "35"
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - build_python_35-{{ .Revision }}
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
-          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/.circleci/run.sh
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -e CIRCLE_PULL_REQUEST="${CIRCLE_PULL_REQUEST}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/.circleci/run.sh
+      - save_cache:
+          key: build_python_35-{{ .Revision }}
+          paths:
+            - out
 
   build_python_36:
     working_directory: ~/test
@@ -35,10 +49,17 @@ jobs:
       - PYVER: "36"
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - build_python_36-{{ .Revision }}
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
-          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/.circleci/run.sh
+          command: docker run -it -e HOST_USER_ID="$(id -u)" -e PYVER="${PYVER}" -e CIRCLE_PULL_REQUEST="${CIRCLE_PULL_REQUEST}" -v "$(pwd)":/home/conda/repo condaforge/linux-anvil /home/conda/repo/.circleci/run.sh
+      - save_cache:
+          key: build_python_36-{{ .Revision }}
+          paths:
+            - out
 
   test_release:
     working_directory: ~/test

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -7,4 +7,7 @@ conda install -yq constructor jinja2
 /home/conda/repo/distclean.py
 /home/conda/repo/build.py --python "${PYVER}" --hash md5 sha1 sha256
 /home/conda/repo/check.py out/miniforge-py${PYVER}-*.sh
-/home/conda/repo/distclean.py
+
+if [ "$CIRCLE_PULL_REQUEST" != "" ]; then
+    /home/conda/repo/distclean.py
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,10 @@ script:
   - ./distclean.py
   - .travis_scripts/run.sh
   - ./check.py "out/miniforge-py${PYVER}-*.sh"
-  - ./distclean.py
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+        ./distclean.py;
+    fi
+
+cache:
+  directories:
+    - out


### PR DESCRIPTION
In order to guarantee that all installers built ok and are ready to release before actually tagging and releasing, we need to block tagging until we know all CIs have passed. We have decided to do this by having Heroku create the tag using a simple Python script as Heroku can block until all CIs pass. The tag will trigger CIs to build again. However we don't want to rebuild the installers a second time (especially if something changes between builds). Instead we would rather release the installers we built on `master`. The issue becomes how to pass the installers between `master` and the tag. We accomplish this by caching with CI, which is what this attempts.