### PR TITLE
Drop CircleCI's `restore_cache` steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,6 @@ jobs:
       - PYVER: "27"
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - build_python_27-{{ .Revision }}
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
@@ -29,9 +26,6 @@ jobs:
       - PYVER: "35"
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - build_python_35-{{ .Revision }}
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
@@ -49,9 +43,6 @@ jobs:
       - PYVER: "36"
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - build_python_36-{{ .Revision }}
       - run:
           command: docker pull condaforge/linux-anvil
       - run:


### PR DESCRIPTION
As we don't actually use the cache in the build jobs and we are planning on having separate deploy jobs that restore the cache, simply drop the `restore_cache` steps from the build jobs on CircleCI.