### PR TITLE
Fetch remote tag before tagging

### DIFF
--- a/release.py
+++ b/release.py
@@ -30,6 +30,12 @@ def main(*argv):
         universal_newlines=True
     ).strip()
 
+    if args.remote:
+        subprocess.call(
+            ["git", "fetch", args.remote, version],
+            universal_newlines=True
+        )
+
     subprocess.check_call(
         shlex.split(
             "git tag {force} -a {tag} -m {tag}".format(


### PR DESCRIPTION
If a remote is provided, fetch the tag we are about to make from it before creating it. This way we can be sure we don't tag the same thing again. Unless of course we want to forcibly overwrite this tag, in which case this tag will be overwritten immediately after it is fetched.