### PR TITLE
Publish GitHub Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,11 @@ jobs:
              git config --global user.name "Foo Bar"
              git config --global user.email "foo@bar.com"
       - run:
-          command: python release.py
+          command: python release.py --tag
       - run:
-          command: ( python release.py ) && false || true
+          command: ( python release.py --tag ) && false || true
       - run:
-          command: python release.py --force
+          command: python release.py --tag --force
 
 workflows:
   version: 2

--- a/release.py
+++ b/release.py
@@ -1,10 +1,43 @@
 #!/usr/bin/env python
 
 import argparse
+import codecs
+import contextlib
+import json
 import os
 import shlex
 import subprocess
 import sys
+
+try:
+    from urllib.error import HTTPError
+    from urllib.request import (
+        Request,
+        urlopen,
+    )
+except ImportError:
+    from urllib2 import (
+        HTTPError,
+        Request,
+        urlopen,
+    )
+
+
+def is_valid_url(url):
+    try:
+        with contextlib.closing(urlopen(url)) as response:
+            return True
+    except HTTPError:
+        return False
+
+
+def request_json(url, data=None, headers={}):
+    if data:
+        data = json.dumps(data)
+    request = Request(url, data, headers=headers)
+    with contextlib.closing(urlopen(request)) as response:
+        reader = codecs.getreader("utf-8")
+        return json.load(reader(response))
 
 
 def main(*argv):
@@ -17,8 +50,23 @@ def main(*argv):
         help="Forcibly tag and push (if `--push` given)."
     )
     parser.add_argument(
-        "--push", metavar="<remote>", dest="remote",
+        "--tag",
+        action="store_true",
+        help="Whether to tag or not."
+    )
+    parser.add_argument(
+        "--remote",
+        help="Specify a remote for pushing and/or publishing."
+    )
+    parser.add_argument(
+        "--push",
+        action="store_true",
         help="Optionally push to specified remote."
+    )
+    parser.add_argument(
+        "--publish",
+        choices=["prerelease", "final"],
+        help="Optionally publish the final release on GitHub."
     )
     args = parser.parse_args(args=argv[1:])
 
@@ -30,27 +78,53 @@ def main(*argv):
         universal_newlines=True
     ).strip()
 
+    if args.push and not args.remote:
+        raise RuntimeError("Need a remote to push.")
+
+    if args.publish:
+        if not args.remote:
+            raise RuntimeError("Need a remote to publish.")
+
+        if "GH_TOKEN" not in os.environ:
+            raise RuntimeError(
+                "Set `GH_TOKEN` environment variable to publish."
+            )
+
+        remote_url = subprocess.check_output(
+            ["git", "remote", "get-url", args.remote],
+            universal_newlines=True
+        ).strip()
+
+        if "github.com" not in remote_url:
+            raise RuntimeError("Publishing only works with GitHub.")
+
+        repo_slug = remote_url.split(".git")[0].split("github.com")[1][1:]
+
+        if not is_valid_url("https://github.com/%s" % repo_slug):
+            raise RuntimeError("Found invalid repo slug: %s" % repo_slug)
+
     if args.remote:
         subprocess.call(
             ["git", "fetch", args.remote, version],
             universal_newlines=True
         )
 
-    subprocess.check_call(
-        shlex.split(
-            "git tag {force} -a {tag} -m {tag}".format(
-                force=args.force, tag=version
-            )
-        ),
-        universal_newlines=True
-    )
+    if args.tag:
+        subprocess.check_call(
+            shlex.split(
+                "git tag {force} -a {tag} -m {tag}".format(
+                    force=args.force, tag=version
+                )
+            ),
+            universal_newlines=True
+        )
 
-    subprocess.check_call(
-        ["git", "--no-pager", "show", version],
-        universal_newlines=True
-    )
+        subprocess.check_call(
+            ["git", "--no-pager", "show", version],
+            universal_newlines=True
+        )
 
-    if args.remote:
+    if args.push:
         subprocess.check_call(
             shlex.split(
                 "git push {force} {remote} {tag}".format(
@@ -59,6 +133,60 @@ def main(*argv):
             ),
             universal_newlines=True
         )
+
+    if args.publish:
+        prerelease = (args.publish == "prerelease")
+        try:
+            release = request_json(
+                (
+                    "https://api.github.com/repos/%s/releases/tags/%s" %
+                    (repo_slug, version)
+                ),
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/vnd.github.v3+json",
+                    "Authorization": "token %s" % os.environ["GH_TOKEN"]
+                }
+            )
+            release_id = release["id"]
+
+            request_json(
+                (
+                    "https://api.github.com/repos/%s/releases/%i"
+                    % (repo_slug, release_id)
+                ),
+                data={
+                    "prerelease": prerelease
+                },
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/vnd.github.v3+json",
+                    "Authorization": "token %s" % os.environ["GH_TOKEN"]
+                }
+            )
+        except HTTPError:
+            version_sha1 = subprocess.check_output(
+                ["git", "rev-list", "-n", "1", version],
+                universal_newlines=True
+            ).strip()
+
+            request_json(
+                (
+                    "https://api.github.com/repos/%s/releases"
+                    % repo_slug
+                ),
+                data={
+                    "tag_name": version,
+                    "target_commitish": version_sha1,
+                    "name": version,
+                    "prerelease": prerelease
+                },
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/vnd.github.v3+json",
+                    "Authorization": "token %s" % os.environ["GH_TOKEN"]
+                }
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This makes some changes to `release.py`. In addition to tagging and pushing the tag, now it can publish GitHub releases either as prereleases or final releases. Also it provides support for modifying existing GitHub releases in addition to making new ones. A GitHub token must be provided via the `GH_TOKEN` environment variable to use any of the publishing behavior. Should add that publishing a release without pushing the tag will just generate a tag remotely (though the metadata between the two may differ).

As a consequence of these additions, there are some changes to the existing behavior of `release.py`. Namely the `--tag` is needed to make a tag. Otherwise no tag is made. Further a `--remote` argument is provided to specify what remote to use when find where to push and/or publish. As a consequence, the `--push` flag is now a boolean flag that takes no arguments (as it uses the argument provided to `--remote`).