### PR TITLE
Drop stray `store_artifacts` in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,6 @@ jobs:
       - restore_cache:
           keys:
             - build_python_27-{{ .Revision }}
-      - store_artifacts:
-          path: out
-          destination: artifacts
 
   deploy_python_35:
     working_directory: ~/test


### PR DESCRIPTION
Follow-up to PR ( https://github.com/jakirkham/miniforge/pull/24 )

This snuck in when making sure tags build. It's a holdover from some test we were doing prior. Hence we now remove.