### PR TITLE
Use regular environment variables in AppVeyor conf

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,11 +7,10 @@ branches:
   - /\d\d\d\d\d\d\d\dT\d\d\d\d\d\dZ/
 
 environment:
-  global:
-    GH_TOKEN:
-      secure: L8UBEbi0DeooYcUYnviUbbsxZagptGEMtXzmNEAn+WgudBzAV32swuNMuxtv9s/d
+  GH_TOKEN:
+    secure: L8UBEbi0DeooYcUYnviUbbsxZagptGEMtXzmNEAn+WgudBzAV32swuNMuxtv9s/d
 
-    PYTHONUNBUFFERED: 1
+  PYTHONUNBUFFERED: 1
 
   matrix:
     - TARGET_ARCH: x86


### PR DESCRIPTION
Somehow trying to pass the `secure` environment variable to `global` was not working out. However it doesn't seem that declaring it as `global` is strictly necessary. Instead declare it as a regular environment variable along with `PYTHONUNBUFFERED`. This should fix the errors seen on `master`.