### PR TITLE
Publish binaries from CIs to the GitHub release

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,10 +48,17 @@ install:
 build: off
 
 test_script:
-  - cmd: distclean
-  - cmd: .appveyor_scripts\\run.bat
-  - cmd: check "out\\miniforge-py%PYVER%-*.exe"
-  - cmd: if defined APPVEYOR_PULL_REQUEST_NUMBER (distclean)
+  - cmd: if "%APPVEYOR_REPO_TAG%" == "false" (
+             distclean &&
+             .appveyor_scripts\\run.bat &&
+             check "out\\miniforge-py%PYVER%-*.exe"
+         ) else (
+             publish --repo "%APPVEYOR_REPO_NAME%" --upload "out\\*" &&
+             distclean
+         )
+  - cmd: if defined APPVEYOR_PULL_REQUEST_NUMBER (
+             distclean
+         )
 
 cache:
   - out

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,8 @@ jobs:
       - restore_cache:
           keys:
             - build_python_27-{{ .Revision }}
+      - run:
+          command: python publish.py --repo "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" --upload "out/*"
 
   deploy_python_35:
     working_directory: ~/test
@@ -87,6 +89,8 @@ jobs:
       - restore_cache:
           keys:
             - build_python_35-{{ .Revision }}
+      - run:
+          command: python publish.py --repo "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" --upload "out/*"
 
   deploy_python_36:
     working_directory: ~/test
@@ -96,6 +100,8 @@ jobs:
       - restore_cache:
           keys:
             - build_python_36-{{ .Revision }}
+      - run:
+          command: python publish.py --repo "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" --upload "out/*"
 
 workflows:
   version: 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,15 @@ install:
   - conda config --set auto_update_conda false
 
 script:
-  - ./distclean.py
-  - .travis_scripts/run.sh
-  - ./check.py "out/miniforge-py${PYVER}-*.sh"
-  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  - if [[ "$TRAVIS_TAG" == "" ]]; then
+        ./distclean.py &&
+        .travis_scripts/run.sh &&
+        ./check.py "out/miniforge-py${PYVER}-*.sh";
+    else
+        ./publish.py --repo "${TRAVIS_REPO_SLUG}" --upload "out/*" &&
+        ./distclean.py;
+    fi
+  - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
         ./distclean.py;
     fi
 


### PR DESCRIPTION
Makes sure that when a tagged build starts, binaries from the CIs are published to the GitHub release. This relies on some external service (i.e. Heroku) to prep the GitHub release and tag so the deployment can occur.