### PR TITLE
Switch from memory protection to access with mmap

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -78,7 +78,7 @@ def main(*argv):
     for each_glob_filename in args.filenames:
         for each_filename in glob.iglob(each_glob_filename):
             with open(each_filename, "rb") as fh:
-                with contextlib.closing(mmap.mmap(fh.fileno(), 0)) as fmm:
+                with contextlib.closing(mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)) as fmm:
                     each_filename = os.path.basename(each_filename)
                     request = Request(
                         release_upload_url + "?name=%s" % each_filename,

--- a/publish.py
+++ b/publish.py
@@ -78,7 +78,7 @@ def main(*argv):
     for each_glob_filename in args.filenames:
         for each_filename in glob.iglob(each_glob_filename):
             with open(each_filename, "rb") as fh:
-                with contextlib.closing(mmap.mmap(fh.fileno(), 0, prot=mmap.ACCESS_READ)) as fmm:
+                with contextlib.closing(mmap.mmap(fh.fileno(), 0)) as fmm:
                     each_filename = os.path.basename(each_filename)
                     request = Request(
                         release_upload_url + "?name=%s" % each_filename,


### PR DESCRIPTION
Uses `access` instead of `prot` (memory protection) with `mmap`, `access` is compatible on Unix and Windows unlike `prot`. As the behavior of `access` is similar, this should be a good substitute and still have the same effect.