### PR TITLE
Only generate `sha256` checksums for installers

### DIFF
--- a/.appveyor_scripts/run.bat
+++ b/.appveyor_scripts/run.bat
@@ -3,5 +3,5 @@
 conda.exe install -yq constructor jinja2
 if errorlevel 1 exit 1
 
-build.py --python "%PYVER%" --hash md5 sha1 sha256
+build.py --python "%PYVER%" --hash sha256
 if errorlevel 1 exit 1

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -5,7 +5,7 @@ set -ex
 conda install -yq constructor jinja2
 
 /home/conda/repo/distclean.py
-/home/conda/repo/build.py --python "${PYVER}" --hash md5 sha1 sha256
+/home/conda/repo/build.py --python "${PYVER}" --hash sha256
 /home/conda/repo/check.py out/miniforge-py${PYVER}-*.sh
 
 if [ "$CIRCLE_PULL_REQUEST" != "" ]; then

--- a/.travis_scripts/run.sh
+++ b/.travis_scripts/run.sh
@@ -3,4 +3,4 @@
 set -ex
 
 conda install -yq constructor jinja2
-./build.py --python "${PYVER}" --hash md5 sha1 sha256
+./build.py --python "${PYVER}" --hash sha256


### PR DESCRIPTION
There is a bit too much clutter in releases by including this many checksums. As `md5` is not cryptographically secure and `sha1` is showing weakness, just use `sha256` only. This is what PyPI uses for packages and has become increasingly common in conda-forge. Only makes sense to follow suit here.