### PR TITLE
Setup Heroku to tag new commits on `master`

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Reconstruct repo locally
+git --version
+git init
+git remote add origin https://github.com/jakirkham/miniforge.git
+git fetch origin
+git checkout -fq "$SOURCE_VERSION"
+
+# Construct dummy git user
+git config --global user.name "Your Name"
+git config --global user.email "you@example.com"
+
+# Get token
+export GH_TOKEN="$(cat $ENV_DIR/GH_TOKEN)"
+
+# Publish release
+python release.py --tag --remote origin --publish prerelease


### PR DESCRIPTION
Configures Heroku to make a GitHub release during its build using the current commit on `master`. This then will trigger the CIs to deploy their results to that release.