### PR TITLE
Drop `name` from header in GitHub upload

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -88,8 +88,7 @@ def main(*argv):
                             "Accept": "application/vnd.github.v3+json",
                             "Authorization": (
                                 "token %s" % os.environ["GH_TOKEN"]
-                            ),
-                            "name": each_filename
+                            )
                         }
                     )
                     with contextlib.closing(urlopen(request)) as response:


### PR DESCRIPTION
This is already being passed in with the URL and it seems to work fine without being in the header. Not sure if it is actually causing issues, but it is redundant. Hence dropping it.