### PR TITLE
Specify the `Content-Length` header for uploads

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -85,6 +85,7 @@ def main(*argv):
                         fmm,
                         headers={
                             "Content-Type": "application/octet-stream",
+                            "Content-Length": len(fmm),
                             "Accept": "application/vnd.github.v3+json",
                             "Authorization": (
                                 "token %s" % os.environ["GH_TOKEN"]


### PR DESCRIPTION
In Python 3.6, it appears there was a change that causes uploads to be chunked by default if the `Content-Length` is not specified. AFAIK this behavior is not supported by GitHub releases. It also results in the connection being closed and reopened while we still have it open triggering `ConnectionResetError`s. To fix this, we send the `Content-Length` in the header after measuring it from the memory mapped file.

ref: https://bugs.python.org/issue12319