### PR TITLE
Set the Travis CI cache timeout to 10mins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,6 @@ script:
     fi
 
 cache:
+  timeout: 600
   directories:
     - out


### PR DESCRIPTION
Travis CI has a default cache timeout of 180s (3mins). However Travis CI performs an update to Homebrew that takes a little over 3mins alone. Not to mention it takes ~1.5mins to download the cached data from the previous session. All in all this is a little under 5mins, which is well over Travis CI's cache timeout. To fix these issues, explicitly set Travis CI's cache timeout generously to stave off these issues by making it 600s (10mins). This should plenty of time even in the worst case for Travis CI to setup the cache.