### PR TITLE
Ensure the CIs' cache directory is always present

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -59,6 +59,7 @@ test_script:
   - cmd: if defined APPVEYOR_PULL_REQUEST_NUMBER (
              distclean
          )
+  - cmd: if not exist out mkdir out
 
 cache:
   - out

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -11,3 +11,5 @@ conda install -yq constructor jinja2
 if [ "$CIRCLE_PULL_REQUEST" != "" ]; then
     /home/conda/repo/distclean.py
 fi
+
+mkdir -p out

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
   - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
         ./distclean.py;
     fi
+  - mkdir -p out
 
 cache:
   timeout: 600


### PR DESCRIPTION
This step ensures that the `out` cache directory always exists on CIs even if `distclean.py` was run. Since we don't know what the behavior of the CIs are when the directory is missing, it makes more sense to have the cache directory present, but ensure it is empty of all content when it should be.

Further as AppVeyor issued warnings about the directory being missing, this should fix those warnings. Also may help with AppVeyor's lingering cache issues.