### PR TITLE
Test `conda` with explicit list and md5 checksums

### DIFF
--- a/checks/check.bat
+++ b/checks/check.bat
@@ -21,5 +21,8 @@ if errorlevel 1 exit 1
 conda list
 if errorlevel 1 exit 1
 
+conda list --explicit --md5
+if errorlevel 1 exit 1
+
 call .\prefix\Scripts\deactivate.bat
 if errorlevel 1 exit 1

--- a/checks/check.bat
+++ b/checks/check.bat
@@ -21,7 +21,7 @@ if errorlevel 1 exit 1
 conda list
 if errorlevel 1 exit 1
 
-conda list --explicit --md5
+conda list --no-show-channel-urls --no-pip
 if errorlevel 1 exit 1
 
 call .\prefix\Scripts\deactivate.bat

--- a/checks/check.sh
+++ b/checks/check.sh
@@ -12,6 +12,6 @@ conda info
 
 conda list
 
-conda list --explicit --md5
+conda list --no-show-channel-urls --no-pip
 
 source deactivate

--- a/checks/check.sh
+++ b/checks/check.sh
@@ -12,4 +12,6 @@ conda info
 
 conda list
 
+conda list --explicit --md5
+
 source deactivate


### PR DESCRIPTION
Related to issue ( https://github.com/jakirkham/miniforge/issues/48 ).

Instead of just listing the packages included in the `root` environment of the installer, also perform an explicit listing with checksum, which, includes the full URL, package name, and md5 checksum for each package. This provides enough info to reproduce the installer's contents exactly.