### PR TITLE
Add `py` variable to `python.jinja`

### DIFF
--- a/build.py
+++ b/build.py
@@ -106,6 +106,7 @@ def main(*argv):
         write_jinja_vars(
             os.path.join(build_dir, "python.jinja"),
             dict(
+                py="%s%s" % (py_ver_maj, py_ver_min),
                 py_ver_maj=py_ver_maj,
                 py_ver_min=py_ver_min,
             )

--- a/src/construct.yaml
+++ b/src/construct.yaml
@@ -1,8 +1,8 @@
 {% from "version.jinja" import version %}
-{% from "python.jinja" import py_ver_maj, py_ver_min %}
+{% from "python.jinja" import py, py_ver_maj, py_ver_min %}
 
 
-name: miniforge-py{{ py_ver_maj }}{{ py_ver_min }}
+name: miniforge-py{{ py }}
 version: {{ version }}
 
 install_in_dependency_order: true


### PR DESCRIPTION
To simplify things a little bit, add the `py` variable to `python.jinja`. This amounts to having the major and minor version jammed together into one number. Similar to how the `py` selector works in `conda-build` recipes. This should simplify some things in `construct.yaml` now and once handling of specific package specs is complete.