### PR TITLE
Fix CircleCI tests

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -7,7 +7,7 @@ conda install -yq constructor jinja2
 
 /home/conda/repo/distclean.py
 /home/conda/repo/build.py --python "${PYVER}" --hash sha256
-/home/conda/repo/check.py /home/conda/repo/out/miniforge-py${PYVER}-*.sh
+/home/conda/repo/check.py "/home/conda/repo/out/miniforge-py${PYVER}-*.sh"
 
 if [ "$CIRCLE_PULL_REQUEST" != "" ]; then
     /home/conda/repo/distclean.py

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -7,7 +7,7 @@ conda install -yq constructor jinja2
 
 /home/conda/repo/distclean.py
 /home/conda/repo/build.py --python "${PYVER}" --hash sha256
-/home/conda/repo/check.py out/miniforge-py${PYVER}-*.sh
+/home/conda/repo/check.py /home/conda/repo/out/miniforge-py${PYVER}-*.sh
 
 if [ "$CIRCLE_PULL_REQUEST" != "" ]; then
     /home/conda/repo/distclean.py

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -ex
+export PYTHONUNBUFFERED=1
 
 conda install -yq constructor jinja2
 

--- a/check.py
+++ b/check.py
@@ -70,7 +70,14 @@ def main(*argv):
         print("Testing installer: %s" % each_installer_fn)
 
         print("Verifying installer version...", end="")
-        git_time_str = git_commit_time(ref="HEAD").strftime("%Y%m%dT%H%M%SZ")
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(base_dir)
+            git_time_str = git_commit_time(ref="HEAD").strftime("%Y%m%dT%H%M%SZ")
+        finally:
+            os.chdir(cwd)
+
         if git_time_str in each_installer_fn:
             print("PASS")
         else:


### PR DESCRIPTION
It appears CircleCI was not picking up the installer for tests due to the shifts in conda-forge's Docker image. This corrects those issues by making sure the absolute path to the installer is provided and that commands in the check phase run correctly regardless of whether the user is in the repo or not. As a bonus `PYTHONUNBUFFERED` is set inside the run script to make sure that the Python code is writing output immediately.